### PR TITLE
make auto-value a provided dependency

### DIFF
--- a/ffwd-client/pom.xml
+++ b/ffwd-client/pom.xml
@@ -21,6 +21,7 @@
         <dependency>
             <groupId>com.google.auto.value</groupId>
             <artifactId>auto-value</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.annotation</groupId>


### PR DESCRIPTION
Avoid leaking auto-value as an undesired transitive dependency to users.